### PR TITLE
about 10% speedup with a manual syscall using inline assembly

### DIFF
--- a/submissions/c/xiver77/fizz.c
+++ b/submissions/c/xiver77/fizz.c
@@ -108,13 +108,14 @@ int main() {
     if (n >= 0) {
       struct iovec v = {b[f], SIZE};
       do {
-        register long rax __asm__ ("rax") = 278;
+        /*register long rax __asm__ ("rax") = 278;
         register long rdi __asm__ ("rdi") = 1;
         register long rsi __asm__ ("rsi") = (long)&v;
         register long rdx __asm__ ("rdx") = 1;
         register long r10 __asm__ ("r10") = 0;
         __asm__ ("syscall" : "+r"(rax) : "r"(rdi), "r"(rsi), "r"(rdx), "r"(r10)
-        : "rcx", "r11");
+        : "rcx", "r11");*/
+        long rax = vmsplice(1, &v, 1, 0);
         if (rax < 0) {
           abort();
         }


### PR DESCRIPTION
The problem is that the calling convention of Linux (SysV) sets all `xmm` registers as clobbered across function calls, and this includes the syscall wrapper of `vmsplice`. By making an inline assembly syscall, I can tell the compiler that the `xmm` register stay fine so that it can preload some more values outside the loop. I hope this still qualifies as "C", as I cannot currently compete with the assembly entries :(